### PR TITLE
Remove incorrect exclude

### DIFF
--- a/library.json
+++ b/library.json
@@ -15,11 +15,6 @@
     "url": "https://github.com/thijse/Arduino-Log/"
   },
   "homepage": "https://github.com/thijse/Arduino-Log/",
-  "export": {
-    "exclude": [
-      "extras",
-    ]
-  },
   "frameworks": [ "arduino",  ],
   "platforms": "*",
   "examples": "examples/*/*.ino"

--- a/library.json
+++ b/library.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/thijse/Arduino-Log/"
   },
   "homepage": "https://github.com/thijse/Arduino-Log/",
-  "frameworks": [ "arduino",  ],
+  "frameworks": [ "arduino" ],
   "platforms": "*",
   "examples": "examples/*/*.ino"
 }


### PR DESCRIPTION
PlatformIO can't pick up the source code correctly due to the incorrect exclude definition (folder doesn't exist) and the broken JSON (trailing array comma). Removing the definition and the comma fixes that.