### PR TITLE
print chars as the actual character instead of their int counterpart

### DIFF
--- a/ArduinoLog.cpp
+++ b/ArduinoLog.cpp
@@ -118,7 +118,7 @@ void Logging::printFormat(const char format, va_list *args) {
   }
 
   if( format == 'c' ) {
-    _logOutput->print(va_arg( *args, int ));
+    _logOutput->print((char) va_arg( *args, int ));
     return;
   }
 


### PR DESCRIPTION
fix from https://github.com/rahuldeo2047/Arduino-logging-library/commit/e62f263e41ed9de70cf58a6868682da978a03968