### PR TITLE
Update LOG_LEVEL_X comments

### DIFF
--- a/ArduinoLog.h
+++ b/ArduinoLog.h
@@ -1,9 +1,9 @@
 /*
-    _   ___ ___  _   _ ___ _  _  ___  _    ___   ___ 
+    _   ___ ___  _   _ ___ _  _  ___  _    ___   ___
    /_\ | _ \   \| | | |_ _| \| |/ _ \| |  / _ \ / __|
   / _ \|   / |) | |_| || || .` | (_) | |_| (_) | (_ |
  /_/ \_\_|_\___/ \___/|___|_|\_|\___/|____\___/ \___|
-                                                     
+
   Log library for Arduino
   version 1.0.0
   https://github.com/thijse/Arduino-Log
@@ -30,7 +30,7 @@ Licensed under the MIT License <http://opensource.org/licenses/MIT>.
 //#define DISABLE_LOGGING
 
 
-#define LOG_LEVEL_SILENT  0 
+#define LOG_LEVEL_SILENT  0
 #define LOG_LEVEL_FATAL   1
 #define LOG_LEVEL_ERROR   2
 #define LOG_LEVEL_WARNING 3
@@ -49,12 +49,12 @@ Licensed under the MIT License <http://opensource.org/licenses/MIT>.
  All methods are able to handle any number of output parameters.
  All methods print out a formated string (like printf).<br>
  To reduce output and program size, reduce loglevel.
- 
+
  Output format string can contain below wildcards. Every wildcard
  must be start with percent sign (\%)
- 
+
 **** Wildcards
- 
+
 * %s	replace with an string (char*)
 * %c	replace with an character
 * %d	replace with an integer value
@@ -68,13 +68,13 @@ Licensed under the MIT License <http://opensource.org/licenses/MIT>.
 
 **** Loglevels
 
-* 0 - LOG_LEVEL_SILENT     no output 
-* 1 - LOG_LEVEL_FATAL      fatal errors 
-* 2 - LOG_LEVEL_ERROR      all errors  
-* 3 - LOG_LEVEL_WARNING    errors, and warnings 
-* 4 - LOG_LEVEL_NOTICE     errors, warnings and notices 
+* 0 - LOG_LEVEL_SILENT     no output
+* 1 - LOG_LEVEL_FATAL      fatal errors
+* 2 - LOG_LEVEL_ERROR      all errors
+* 3 - LOG_LEVEL_WARNING    errors and warnings
+* 4 - LOG_LEVEL_NOTICE     errors, warnings and notices
 * 5 - LOG_LEVEL_TRACE      errors, warnings, notices, traces
-* 6 - LOG_LEVEL_VERBOSE    all 
+* 6 - LOG_LEVEL_VERBOSE    all
 */
 
 class Logging {
@@ -83,14 +83,14 @@ private:
 	bool _showLevel;
     Print* _logOutput;
 public:
-    /*! 
+    /*!
 	 * default Constructor
 	 */
     Logging()
       : _level(LOG_LEVEL_SILENT),
 	    _showLevel(true),
         _logOutput(NULL) {}
-	
+
 
     /**
     * Initializing, must be called as first. Note that if you use
@@ -104,48 +104,51 @@ public:
     void begin(int level, Print *output, bool showLevel = true);
 
 	    /**
-	* Output an error message. Output message contains
-	* ERROR: followed by original msg
-	* Error messages are printed out, at every loglevel
-	* except 0 ;-)
+	* Output a fatal error message. Output message contains
+	* F: followed by original message
+	* Fatal error messages are printed out at
+	* loglevels >= LOG_LEVEL_FATAL
+	*
 	* \param msg format string to output
 	* \param ... any number of variables
 	* \return void
 	*/
   template <class T> void fatal(T msg, ...){
-#ifndef DISABLE_LOGGING	  
+#ifndef DISABLE_LOGGING
     if (LOG_LEVEL_FATAL <= _level) {
       if (_showLevel) _logOutput->print("F: ");
       va_list args;
       va_start(args, msg);
       print(msg,args);
     }
-#endif	
+#endif
   }
-	
+
     /**
 	* Output an error message. Output message contains
-	* ERROR: followed by original msg
-	* Error messages are printed out, at every loglevel
-	* except 0 ;-)
+	* E: followed by original message
+	* Error messages are printed out at
+	* loglevels >= LOG_LEVEL_ERROR
+	*
 	* \param msg format string to output
 	* \param ... any number of variables
 	* \return void
 	*/
   template <class T> void error(T msg, ...){
-#ifndef DISABLE_LOGGING	  
+#ifndef DISABLE_LOGGING
     if (LOG_LEVEL_ERROR <= _level) {
       if (_showLevel) _logOutput->print("E: ");
       va_list args;
       va_start(args, msg);
       print(msg,args);
     }
-#endif	
+#endif
   }
     /**
-	* Output an info message. Output message contains
-	* Info messages are printed out at l
-	* loglevels >= LOG_LEVEL_INFOS
+	* Output a warning message. Output message contains
+	* W: followed by original message
+	* Warning messages are printed out at
+	* loglevels >= LOG_LEVEL_WARNING
 	*
 	* \param msg format string to output
 	* \param ... any number of variables
@@ -153,19 +156,20 @@ public:
 	*/
 
   template <class T> void warning(T msg, ...){
-#ifndef DISABLE_LOGGING	  
+#ifndef DISABLE_LOGGING
     if (LOG_LEVEL_WARNING <= _level) {
       if (_showLevel) _logOutput->print("W: ");
       va_list args;
       va_start(args, msg);
       print(msg,args);
     }
-#endif		
+#endif
   }
     /**
-	* Output an debug message. Output message contains
-	* Debug messages are printed out at l
-	* loglevels >= LOG_LEVEL_DEBUG
+	* Output a notice message. Output message contains
+	* N: followed by original message
+	* Notice messages are printed out at
+	* loglevels >= LOG_LEVEL_NOTICE
 	*
 	* \param msg format string to output
 	* \param ... any number of variables
@@ -173,38 +177,40 @@ public:
 	*/
 
   template <class T> void notice(T msg, ...){
-#ifndef DISABLE_LOGGING	  
+#ifndef DISABLE_LOGGING
     if (LOG_LEVEL_NOTICE <= _level) {
 	  if (_showLevel) _logOutput->print("N: ");
       va_list args;
       va_start(args, msg);
       print(msg,args);
     }
-#endif		
+#endif
   }
     /**
 	* Output a trace message. Output message contains
-	* Debug messages are printed out at l
-	* loglevels >= LOG_LEVEL_VERBOSE
+	* N: followed by original message
+	* Trace messages are printed out at
+	* loglevels >= LOG_LEVEL_TRACE
 	*
 	* \param msg format string to output
 	* \param ... any number of variables
 	* \return void
 	*/
   template <class T> void trace(T msg, ...){
-#ifndef DISABLE_LOGGING	  
+#ifndef DISABLE_LOGGING
     if (LOG_LEVEL_TRACE <= _level) {
 	  if (_showLevel) _logOutput->print("T: ");
       va_list args;
       va_start(args, msg);
       print(msg,args);
     }
-#endif		
-  }	
-	
+#endif
+  }
+
     /**
-	* Output an verbose message. Output message contains
-	* Debug messages are printed out at l
+	* Output a verbose message. Output message contains
+	* V: followed by original message
+	* Debug messages are printed out at
 	* loglevels >= LOG_LEVEL_VERBOSE
 	*
 	* \param msg format string to output
@@ -212,16 +218,16 @@ public:
 	* \return void
 	*/
   template <class T> void verbose(T msg, ...){
-#ifndef DISABLE_LOGGING	  
+#ifndef DISABLE_LOGGING
     if (LOG_LEVEL_VERBOSE <= _level) {
 	  if (_showLevel) _logOutput->print("V: ");
       va_list args;
       va_start(args, msg);
       print(msg,args);
     }
-#endif		
+#endif
   }
-    
+
 private:
     void print(const char *format, va_list args);
     void print(const __FlashStringHelper *format, va_list args);
@@ -230,7 +236,4 @@ private:
 
 extern Logging Log;
 #endif
-
-
-
 

--- a/examples/Log/Log.ino
+++ b/examples/Log/Log.ino
@@ -21,7 +21,7 @@ void setup() {
     randomSeed(analogRead(0));
     // Pass log level, whether to show log level, and print interface. 
     // Available levels are: 
-    // LOG_LEVEL_SILENT, LOG_LEVEL_FATAL, LOG_LEVEL_ERROR, LOG_LEVEL_WARNING, LOG_LEVEL_NOTICE, LOG_LEVEL_VERBOSE
+    // LOG_LEVEL_SILENT, LOG_LEVEL_FATAL, LOG_LEVEL_ERROR, LOG_LEVEL_WARNING, LOG_LEVEL_NOTICE, LOG_LEVEL_TRACE, LOG_LEVEL_VERBOSE
     // Note: if you want to fully remove all logging code, uncomment #define DISABLE_LOGGING in Logging.h
     //       this will significantly reduce your project size
     

--- a/keywords.txt
+++ b/keywords.txt
@@ -30,9 +30,11 @@ Logging	KEYWORD2	Logging library
 #######################################
 #	Constants	(LITERAL1)
 #######################################
-LOG_LEVEL_NOOUTPUT	LITERAL1	Constants
-LOG_LEVEL_ERRORS	LITERAL1	Constants
-LOG_LEVEL_INFOS	LITERAL1	Constants
-LOG_LEVEL_DEBUG	LITERAL1	Constants
+LOG_LEVEL_SILENT	LITERAL1	Constants
+LOG_LEVEL_FATAL	LITERAL1	Constants
+LOG_LEVEL_ERROR	LITERAL1	Constants
+LOG_LEVEL_WARNING	LITERAL1	Constants
+LOG_LEVEL_NOTICE	LITERAL1	Constants
+LOG_LEVEL_TRACE	LITERAL1	Constants
 LOG_LEVEL_VERBOSE	LITERAL1	Constants
 


### PR DESCRIPTION
The log levels in keywords.txt did not match existing log levels.
Comments did not match the code.

Also removed trailing whitespace.

Big thanks to @thijse for maintaining this library.