### PR TITLE
Add prefix and suffix possibility

### DIFF
--- a/ArduinoLog.cpp
+++ b/ArduinoLog.cpp
@@ -37,6 +37,14 @@ void Logging::begin(int level, Print* logOutput, bool showLevel){
     _logOutput = logOutput;
 }
 
+void Logging::setPrefix(printfunction f){
+    _prefix = f;
+}
+
+void Logging::setSuffix(printfunction f){
+    _suffix = f;
+}
+
 void Logging::print(const __FlashStringHelper *format, va_list args) {
 #ifndef DISABLE_LOGGING	  	
   PGM_P p = reinterpret_cast<PGM_P>(format);
@@ -145,11 +153,4 @@ void Logging::printFormat(const char format, va_list *args) {
 }
  
 Logging Log = Logging();
-
- 
- 
-  
-
-
-
 

--- a/examples/Log/Log.ino
+++ b/examples/Log/Log.ino
@@ -26,6 +26,8 @@ void setup() {
     //       this will significantly reduce your project size
 
     Log.begin(LOG_LEVEL_VERBOSE, &Serial);
+    //Log.setPrefix(printTimestamp); // Uncomment to get timestamps as prefix
+    //Log.setSuffix(printNewline); // Uncomment to get newline as suffix
 
     //Start logging
 
@@ -68,3 +70,14 @@ void loop() {
     Log.verbose  (F("Log as Verbose with bool value   : %T" CR CR CR               ), boolValue2);
     delay(5000);
 }
+
+void printTimestamp(Print* _logOutput) {
+  char c[12];
+  int m = sprintf(c, "%10lu ", millis());
+  _logOutput->print(c);
+}
+
+void printNewline(Print* _logOutput) {
+  _logOutput->print('\n');
+}
+

--- a/keywords.txt
+++ b/keywords.txt
@@ -21,6 +21,8 @@ notice	KEYWORD2	info output
 trace 	KEYWORD2	trace output
 verbose	KEYWORD2	verbose output
 begin	KEYWORD2	initialize library
+setPrefix	KEYWORD2	set prefix function
+setSuffix	KEYWORD2	set suffix function
 
 #######################################
 #	Instances	(KEYWORD2)


### PR DESCRIPTION
My use case for prefix is to print a timestamp at start of each
log line. The suffix function can be used to avoid having to add
"CR" at the end of each log message.

The varadic template used to clean up the code requires C++11.
The Arduino IDE supports C++11 since Jul 16, 2015 (version
1.6.6 it seems) so I don'think it will cause problems, but
feedback is welcome.