### PR TITLE
Remove invalid reference link from keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,8 +5,8 @@
 #######################################
 #	Instances	(KEYWORD1)
 #######################################
-Logging	KEYWORD1	Logging library
-Log	    KEYWORD1	Logging library
+Logging	KEYWORD1
+Log	    KEYWORD1
 #######################################
 #	Datatypes	(KEYWORD1)
 #######################################
@@ -14,20 +14,20 @@ Log	    KEYWORD1	Logging library
 #######################################
 #	Methods	and	Functions	(KEYWORD2)
 ####################################### 
-fatal	KEYWORD2	fatal error output
-error	KEYWORD2	error output
-warning	KEYWORD2	warning output
-notice	KEYWORD2	info output
-trace 	KEYWORD2	trace output
-verbose	KEYWORD2	verbose output
-begin	KEYWORD2	initialize library
-setPrefix	KEYWORD2	set prefix function
-setSuffix	KEYWORD2	set suffix function
+fatal	KEYWORD2
+error	KEYWORD2
+warning	KEYWORD2
+notice	KEYWORD2
+trace 	KEYWORD2
+verbose	KEYWORD2
+begin	KEYWORD2
+setPrefix	KEYWORD2
+setSuffix	KEYWORD2
 
 #######################################
 #	Instances	(KEYWORD2)
 #######################################
-Logging	KEYWORD2	Logging library
+Logging	KEYWORD2
 
 #######################################
 #	Constants	(LITERAL1)


### PR DESCRIPTION
The third field of keywords.txt is used to provide Arduino Language/Libraries Reference links, which are accessed from the Arduino IDE by highlighting the keyword and then selecting "Find in Reference" from the Help or right click menu. Adding values to this field that do not match any existing reference pages results in a "Could not open the URL" error.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywordstxt-format