### PR TITLE
Added a S format specifier for flash stored string

### DIFF
--- a/ArduinoLog.cpp
+++ b/ArduinoLog.cpp
@@ -88,6 +88,12 @@ void Logging::printFormat(const char format, va_list *args) {
     return;
   }
 
+  if( format == 'S' ) {
+    register __FlashStringHelper *s = (__FlashStringHelper *)va_arg( *args, int );
+    _logOutput->print(s);
+    return;
+  }
+  
   if( format == 'd' || format == 'i') {
     _logOutput->print(va_arg( *args, int ),DEC);
     return;


### PR DESCRIPTION
Using this format specifier, you can format a string using flash stored arguments.

```cpp
const __FlashStringHelper * anArgument = F("Something");
Log.verbose("%S happened !", anArgument);
```

I'm using it for a while now in a project to output formatted AT commands to a SIM808 chip while keeping the memory footprint as small as possible.