### PR TITLE
Don't cast the va_arg for __FlashStringHelper* or char* because it crashes on x86

### DIFF
--- a/ArduinoLog.cpp
+++ b/ArduinoLog.cpp
@@ -172,12 +172,12 @@ void Logging::printFormat(const char format, va_list *args) {
 	}
 	else if (format == 's')
 	{
-		register char *s = (char *)va_arg(*args, int);
+		register char *s = va_arg(*args, char *);
 		_logOutput->print(s);
 	}
 	else if (format == 'S')
 	{
-		register __FlashStringHelper *s = (__FlashStringHelper *)va_arg(*args, int);
+		register __FlashStringHelper *s = va_arg(*args, __FlashStringHelper *);
 		_logOutput->print(s);
 	}
 	else if (format == 'd' || format == 'i')


### PR DESCRIPTION
I verified that it works on x86 and still works on my M4 express.