### PR TITLE
Add va_end() to properly close va_list 'args'

### DIFF
--- a/ArduinoLog.h
+++ b/ArduinoLog.h
@@ -369,6 +369,7 @@ private:
 		{
 		    _logOutput->print(CR);
 		}
+        va_end(args);
 #endif
 	}
 


### PR DESCRIPTION
cppcheck (used in platform.io check) complained about the va_list not being closed before returning from printLevel