### PR TITLE
Fix ArduinoLog not compiling with #define DISABLE_LOGGING

### DIFF
--- a/ArduinoLog.h
+++ b/ArduinoLog.h
@@ -328,7 +328,9 @@ private:
 
 	void print(const Printable& obj, va_list args)
 	{
-		_logOutput->print(obj);
+		#ifndef DISABLE_LOGGING
+		    _logOutput->print(obj);
+		#endif
 	}
 
 	void printFormat(const char format, va_list *args);


### PR DESCRIPTION
Before i got this error:
```
In file included from src/main.h:3:0,                                                                                                                                 
                 from src/main.cpp:1:                                                                                                                                 
.pio/libdeps/uno/ArduinoLog/ArduinoLog.h: In member function 'void Logging::print(const Printable&, va_list)':                                                        
.pio/libdeps/uno/ArduinoLog/ArduinoLog.h:329:3: error: '_logOutput' was not declared in this scope                                                                    
   _logOutput->print(obj);                                                                                                                                            
   ^                                                                                                                                                                  
In file included from src/main.h:7:0,                                                                                                                                 
                 from src/main.cpp:1: 
 ```

