### PR TITLE
Fix: clearSuffix was clearing the prefix

### DIFF
--- a/ArduinoLog.cpp
+++ b/ArduinoLog.cpp
@@ -96,7 +96,7 @@ void Logging::setSuffix(printfunction f)
 void Logging::clearSuffix()
 {
 #ifndef DISABLE_LOGGING
-	_prefix = nullptr;
+	_suffix = nullptr;
 #endif
 }
 


### PR DESCRIPTION
Fix: clearSuffix was clearing the prefix instead of the suffix