### PR TITLE
Added an option to not automatically instantiate a Log object.

### DIFF
--- a/ArduinoLog.cpp
+++ b/ArduinoLog.cpp
@@ -262,5 +262,8 @@ void Logging::printFormat(const char format, va_list *args) {
 	}
 #endif
 }
- 
+
+#ifndef __DO_NOT_INSTANTIATE__
 Logging Log = Logging();
+#endif
+


### PR DESCRIPTION
In some cases you do not want the Log object to be instantiated automatically by the library. Reasons could be that you want to control the heap memory segment type that gets allocated for the log object, or that you want to inherit the log base to another derived class. This commit adds a flag "__DO_NOT_INSTANTIATE__" that if set omits the automatic instantiation. The change is backwards compatible.