### PR TITLE
Adding togglable ANSI colored logs

### DIFF
--- a/ArduinoLog.cpp
+++ b/ArduinoLog.cpp
@@ -31,11 +31,12 @@ SOFTWARE.
 
 #include "ArduinoLog.h"
 
-void Logging::begin(int level, Print* logOutput, bool showLevel)
+void Logging::begin(int level, Print* logOutput, bool showLevel, bool showColors)
 {
 #ifndef DISABLE_LOGGING
 	setLevel(level);
 	setShowLevel(showLevel);
+	setShowColors(showColors);
 	_logOutput = logOutput;
 #endif
 }
@@ -67,6 +68,22 @@ bool Logging::getShowLevel() const
 {
 #ifndef DISABLE_LOGGING
 	return _showLevel;
+#else
+	return false;
+#endif
+}
+
+void Logging::setShowColors(bool showColors)
+{
+#ifndef DISABLE_LOGGING
+	_showColors = showColors;
+#endif
+}
+
+bool Logging::getShowColors() const
+{
+#ifndef DISABLE_LOGGING
+	return _showColors;
 #else
 	return false;
 #endif

--- a/ArduinoLog.h
+++ b/ArduinoLog.h
@@ -46,6 +46,14 @@ typedef void (*printfunction)(Print*, int);
 #define LOG_LEVEL_TRACE   5
 #define LOG_LEVEL_VERBOSE 6
 
+#define BOLDRED F("\033[1;31m")
+#define BOLDWHITE F("\033[1;37m")
+#define RED "\033[;31m"
+#define YELLOW "\033[;33m"
+#define GREEN "\033[;32m"
+#define WHITE "\033[;37m"
+#define ENDCOLOUR "\033[0m"
+#define BLACK "\033[;30m"
 #define CR "\n"
 #define LF "\r"
 #define NL "\n\r"
@@ -190,13 +198,17 @@ public:
 	 */
   template <class T, typename... Args> void fatal(T msg, Args... args){
 #ifndef DISABLE_LOGGING
+		printLevel(LOG_LEVEL_FATAL, false, BOLDRED, args...);
     printLevel(LOG_LEVEL_FATAL, false, msg, args...);
+		printLevel(LOG_LEVEL_FATAL, false, ENDCOLOUR, args...);
 #endif
   }
 
   template <class T, typename... Args> void fatalln(T msg, Args... args){
 #ifndef DISABLE_LOGGING
-    printLevel(LOG_LEVEL_FATAL, true, msg, args...);
+		printLevel(LOG_LEVEL_FATAL, false, BOLDRED, args...);
+    printLevel(LOG_LEVEL_FATAL, false, msg, args...);
+		printLevel(LOG_LEVEL_FATAL, true, ENDCOLOUR, args...);
 #endif
   }
 
@@ -212,13 +224,17 @@ public:
 	 */
   template <class T, typename... Args> void error(T msg, Args... args){
 #ifndef DISABLE_LOGGING
+		printLevel(LOG_LEVEL_ERROR, false, RED, args...);
     printLevel(LOG_LEVEL_ERROR, false, msg, args...);
+		printLevel(LOG_LEVEL_ERROR, false, ENDCOLOUR, args...);
 #endif
   }
   
    template <class T, typename... Args> void errorln(T msg, Args... args){
 #ifndef DISABLE_LOGGING
-    printLevel(LOG_LEVEL_ERROR, true, msg, args...);
+		printLevel(LOG_LEVEL_ERROR, false, RED, args...);
+    printLevel(LOG_LEVEL_ERROR, false, msg, args...);
+		printLevel(LOG_LEVEL_ERROR, true, ENDCOLOUR, args...);
 #endif
   } 
 	/**
@@ -233,13 +249,17 @@ public:
 	 */
   template <class T, typename... Args> void warning(T msg, Args...args){
 #ifndef DISABLE_LOGGING
+		printLevel(LOG_LEVEL_WARNING, false, YELLOW, args...);
     printLevel(LOG_LEVEL_WARNING, false, msg, args...);
+		printLevel(LOG_LEVEL_WARNING, false, ENDCOLOUR, args...);
 #endif
   }
   
    template <class T, typename... Args> void warningln(T msg, Args...args){
 #ifndef DISABLE_LOGGING
-    printLevel(LOG_LEVEL_WARNING, true, msg, args...);
+		printLevel(LOG_LEVEL_WARNING, false, YELLOW, args...);
+    printLevel(LOG_LEVEL_WARNING, false, msg, args...);
+		printLevel(LOG_LEVEL_WARNING, true, ENDCOLOUR, args...);
 #endif
   } 
 
@@ -255,25 +275,33 @@ public:
 	 */
   template <class T, typename... Args> void notice(T msg, Args...args){
 #ifndef DISABLE_LOGGING
+		printLevel(LOG_LEVEL_NOTICE, false, GREEN, args...);
     printLevel(LOG_LEVEL_NOTICE, false, msg, args...);
+		printLevel(LOG_LEVEL_NOTICE, false, ENDCOLOUR, args...);
 #endif
   }
   
   template <class T, typename... Args> void noticeln(T msg, Args...args){
 #ifndef DISABLE_LOGGING
-    printLevel(LOG_LEVEL_NOTICE, true, msg, args...);
+		printLevel(LOG_LEVEL_NOTICE, false, GREEN, args...);
+    printLevel(LOG_LEVEL_NOTICE, false, msg, args...);
+		printLevel(LOG_LEVEL_NOTICE, true, ENDCOLOUR, args...);
 #endif
   }  
 
   template <class T, typename... Args> void info(T msg, Args...args) {
 #ifndef DISABLE_LOGGING
+		printLevel(LOG_LEVEL_INFO, false, BOLDWHITE, args...);
 	  printLevel(LOG_LEVEL_INFO, false, msg, args...);
+		rintLevel(LOG_LEVEL_INFO, false, ENDCOLOUR, args...);
 #endif
   }
 
   template <class T, typename... Args> void infoln(T msg, Args...args) {
 #ifndef DISABLE_LOGGING
-	  printLevel(LOG_LEVEL_INFO, true, msg, args...);
+		printLevel(LOG_LEVEL_INFO, false, BOLDWHITE, args...);
+	  printLevel(LOG_LEVEL_INFO, false, msg, args...);
+		rintLevel(LOG_LEVEL_INFO, true, ENDCOLOUR, args...);
 #endif
   }
 
@@ -311,13 +339,17 @@ public:
 	 */
   template <class T, typename... Args> void verbose(T msg, Args... args){
 #ifndef DISABLE_LOGGING
+		printLevel(LOG_LEVEL_VERBOSE, false, BLACK, args...);
     printLevel(LOG_LEVEL_VERBOSE, false, msg, args...);
+		printLevel(LOG_LEVEL_VERBOSE, false, ENDCOLOUR, args...);
 #endif
   }
 
   template <class T, typename... Args> void verboseln(T msg, Args... args){
 #ifndef DISABLE_LOGGING
-    printLevel(LOG_LEVEL_VERBOSE, true, msg, args...);
+		printLevel(LOG_LEVEL_VERBOSE, false, BLACK, args...);
+    printLevel(LOG_LEVEL_VERBOSE, false, msg, args...);
+		printLevel(LOG_LEVEL_VERBOSE, true, ENDCOLOUR, args...);
 #endif
   }
 
@@ -349,12 +381,6 @@ private:
 		if (_prefix != NULL)
 		{
 			_prefix(_logOutput, level);
-		}
-
-		if (_showLevel) {
-			static const char levels[] = "FEWITV";
-			_logOutput->print(levels[level - 1]);
-			_logOutput->print(": ");
 		}
 
 		va_list args;

--- a/ArduinoLog.h
+++ b/ArduinoLog.h
@@ -52,8 +52,8 @@ typedef void (*printfunction)(Print*, int);
 #define YELLOW "\033[;33m"
 #define GREEN "\033[;32m"
 #define WHITE "\033[;37m"
+#define BLACK "\033[;38;5;240m"
 #define ENDCOLOUR "\033[0m"
-#define BLACK "\033[;30m"
 #define CR "\n"
 #define LF "\r"
 #define NL "\n\r"
@@ -105,7 +105,8 @@ public:
 	Logging()
 #ifndef DISABLE_LOGGING
 		: _level(LOG_LEVEL_SILENT),
-   		  _showLevel(true),
+		  _showLevel(true),
+		  _showColors(false),
 		  _logOutput(NULL)
 #endif
 	{
@@ -119,10 +120,12 @@ public:
 	 * 
 	 * \param level - logging levels <= this will be logged.
 	 * \param printer - place that logging output will be sent to.
+	 * \param showLevel - if true, the level will be shown in the output.
+	 * \param showColors - if true, the color will be shown in the output.
 	 * \return void
 	 *
 	 */
-	void begin(int level, Print *output, bool showLevel = true);
+	void begin(int level, Print *output, bool showLevel = true, bool showColors = false);
 
 	/**
 	 * Set the log level.
@@ -155,6 +158,23 @@ public:
 	 *         false otherwise.
 	 */
 	bool getShowLevel() const;
+
+	/**
+	 * Set whether to show the log colors.
+	 *
+	 * \param showColors - true if the log colors should be shown for each log
+	 *                    false otherwise.
+	 * \return void
+	 */
+	void setShowColors(bool showColors);
+
+	/**
+	 * Get whether the log colors are shown during logging
+	 *
+	 * \return true if the log colors are shown for each log
+	 *         false otherwise.
+	 */
+	bool getShowColors() const;
 
 	/**
 	 * Sets a function to be called before each log command.
@@ -198,17 +218,13 @@ public:
 	 */
   template <class T, typename... Args> void fatal(T msg, Args... args){
 #ifndef DISABLE_LOGGING
-		printLevel(LOG_LEVEL_FATAL, false, BOLDRED, args...);
-    printLevel(LOG_LEVEL_FATAL, false, msg, args...);
-		printLevel(LOG_LEVEL_FATAL, false, ENDCOLOUR, args...);
+		printLevel(LOG_LEVEL_FATAL, false, msg, args...);
 #endif
   }
 
   template <class T, typename... Args> void fatalln(T msg, Args... args){
 #ifndef DISABLE_LOGGING
-		printLevel(LOG_LEVEL_FATAL, false, BOLDRED, args...);
-    printLevel(LOG_LEVEL_FATAL, false, msg, args...);
-		printLevel(LOG_LEVEL_FATAL, true, ENDCOLOUR, args...);
+		printLevel(LOG_LEVEL_FATAL, true, msg, args...);
 #endif
   }
 
@@ -224,17 +240,13 @@ public:
 	 */
   template <class T, typename... Args> void error(T msg, Args... args){
 #ifndef DISABLE_LOGGING
-		printLevel(LOG_LEVEL_ERROR, false, RED, args...);
-    printLevel(LOG_LEVEL_ERROR, false, msg, args...);
-		printLevel(LOG_LEVEL_ERROR, false, ENDCOLOUR, args...);
+		printLevel(LOG_LEVEL_ERROR, false, msg, args...);
 #endif
   }
   
    template <class T, typename... Args> void errorln(T msg, Args... args){
 #ifndef DISABLE_LOGGING
-		printLevel(LOG_LEVEL_ERROR, false, RED, args...);
-    printLevel(LOG_LEVEL_ERROR, false, msg, args...);
-		printLevel(LOG_LEVEL_ERROR, true, ENDCOLOUR, args...);
+		printLevel(LOG_LEVEL_ERROR, true, msg, args...);
 #endif
   } 
 	/**
@@ -249,17 +261,13 @@ public:
 	 */
   template <class T, typename... Args> void warning(T msg, Args...args){
 #ifndef DISABLE_LOGGING
-		printLevel(LOG_LEVEL_WARNING, false, YELLOW, args...);
-    printLevel(LOG_LEVEL_WARNING, false, msg, args...);
-		printLevel(LOG_LEVEL_WARNING, false, ENDCOLOUR, args...);
+		printLevel(LOG_LEVEL_WARNING, false, msg, args...);
 #endif
   }
   
    template <class T, typename... Args> void warningln(T msg, Args...args){
 #ifndef DISABLE_LOGGING
-		printLevel(LOG_LEVEL_WARNING, false, YELLOW, args...);
-    printLevel(LOG_LEVEL_WARNING, false, msg, args...);
-		printLevel(LOG_LEVEL_WARNING, true, ENDCOLOUR, args...);
+		printLevel(LOG_LEVEL_WARNING, true, msg, args...);
 #endif
   } 
 
@@ -275,33 +283,25 @@ public:
 	 */
   template <class T, typename... Args> void notice(T msg, Args...args){
 #ifndef DISABLE_LOGGING
-		printLevel(LOG_LEVEL_NOTICE, false, GREEN, args...);
-    printLevel(LOG_LEVEL_NOTICE, false, msg, args...);
-		printLevel(LOG_LEVEL_NOTICE, false, ENDCOLOUR, args...);
+		printLevel(LOG_LEVEL_NOTICE, false, msg, args...);
 #endif
   }
   
   template <class T, typename... Args> void noticeln(T msg, Args...args){
 #ifndef DISABLE_LOGGING
-		printLevel(LOG_LEVEL_NOTICE, false, GREEN, args...);
-    printLevel(LOG_LEVEL_NOTICE, false, msg, args...);
-		printLevel(LOG_LEVEL_NOTICE, true, ENDCOLOUR, args...);
+		printLevel(LOG_LEVEL_NOTICE, true, msg, args...);
 #endif
   }  
 
   template <class T, typename... Args> void info(T msg, Args...args) {
 #ifndef DISABLE_LOGGING
-		printLevel(LOG_LEVEL_INFO, false, BOLDWHITE, args...);
-	  printLevel(LOG_LEVEL_INFO, false, msg, args...);
-		rintLevel(LOG_LEVEL_INFO, false, ENDCOLOUR, args...);
+		printLevel(LOG_LEVEL_INFO, false, msg, args...);
 #endif
   }
 
   template <class T, typename... Args> void infoln(T msg, Args...args) {
 #ifndef DISABLE_LOGGING
-		printLevel(LOG_LEVEL_INFO, false, BOLDWHITE, args...);
-	  printLevel(LOG_LEVEL_INFO, false, msg, args...);
-		rintLevel(LOG_LEVEL_INFO, true, ENDCOLOUR, args...);
+		printLevel(LOG_LEVEL_INFO, true, msg, args...);
 #endif
   }
 
@@ -339,17 +339,13 @@ public:
 	 */
   template <class T, typename... Args> void verbose(T msg, Args... args){
 #ifndef DISABLE_LOGGING
-		printLevel(LOG_LEVEL_VERBOSE, false, BLACK, args...);
-    printLevel(LOG_LEVEL_VERBOSE, false, msg, args...);
-		printLevel(LOG_LEVEL_VERBOSE, false, ENDCOLOUR, args...);
+		printLevel(LOG_LEVEL_VERBOSE, false, msg, args...);
 #endif
   }
 
   template <class T, typename... Args> void verboseln(T msg, Args... args){
 #ifndef DISABLE_LOGGING
-		printLevel(LOG_LEVEL_VERBOSE, false, BLACK, args...);
-    printLevel(LOG_LEVEL_VERBOSE, false, msg, args...);
-		printLevel(LOG_LEVEL_VERBOSE, true, ENDCOLOUR, args...);
+		printLevel(LOG_LEVEL_VERBOSE, true, msg, args...);
 #endif
   }
 
@@ -376,11 +372,41 @@ private:
 		{
 			level = LOG_LEVEL_SILENT;
 		}
-			
+
+		if (_showColors)
+		{
+			switch (level)
+			{
+			case LOG_LEVEL_FATAL:
+				_logOutput->print(BOLDRED);
+				break;
+			case LOG_LEVEL_ERROR:
+				_logOutput->print(RED);
+				break;
+			case LOG_LEVEL_WARNING:
+				_logOutput->print(YELLOW);
+				break;
+			case LOG_LEVEL_NOTICE:
+				_logOutput->print(GREEN);
+				break;
+			case LOG_LEVEL_VERBOSE:
+				_logOutput->print(BLACK);
+				break;
+			default:
+				break;
+			}
+		}
 
 		if (_prefix != NULL)
 		{
 			_prefix(_logOutput, level);
+		}
+
+		if (_showLevel)
+		{
+			static const char levels[] = "FEWITV";
+			_logOutput->print(levels[level - 1]);
+			_logOutput->print(": ");
 		}
 
 		va_list args;
@@ -395,12 +421,17 @@ private:
 		{
 		    _logOutput->print(CR);
 		}
+		if (_showColors)
+		{
+			_logOutput->print(ENDCOLOUR);
+		}
 #endif
 	}
 
 #ifndef DISABLE_LOGGING
 	int _level;
 	bool _showLevel;
+	bool _showColors;
 	Print* _logOutput;
 
 	printfunction _prefix = NULL;


### PR DESCRIPTION
This is a fork of  @xHeler 's idea of implementing ANSI colours to distinguish different log types.

I have added the possibility to enable/disable (default disabled) this functionality either from the constructor:

```c
Log.begin(level, &Serial, showLevel, showColors);
```

or by calling the specific method:

```c
Log.setShowColors(showColors);
```

I also improved the readability of the code by refactoring the part that deals with printing ANSI codes