### PR TITLE
fix: allow logging of a single character

### DIFF
--- a/ArduinoLog.cpp
+++ b/ArduinoLog.cpp
@@ -163,6 +163,13 @@ void Logging::print(const char *format, va_list args) {
 #endif
 }
 
+void Logging::print(const char c, va_list args) 
+{
+#ifndef DISABLE_LOGGING
+   _logOutput->print(c);
+#endif
+}
+
 void Logging::printFormat(const char format, va_list *args) {
 #ifndef DISABLE_LOGGING
 	if (format == '\0') return;

--- a/ArduinoLog.cpp
+++ b/ArduinoLog.cpp
@@ -227,6 +227,20 @@ void Logging::printFormat(const char format, va_list *args) {
 	{
 		_logOutput->print(va_arg(*args, long), DEC);
 	}
+   else if (format == 'L')
+   {
+      _logOutput->print("0x");
+		//_logOutput->print(va_arg(*args, int), HEX);
+	   uint32_t h = (uint32_t) va_arg( *args, long );
+      if (h <= 0xF) _logOutput->print('0');
+      else if (h <= 0xFF); // Do nothing
+      else if (h <= 0xFFF) _logOutput->print('0');
+      else if (h <= 0xFFFF); // Do nothing
+      else if (h <= 0xFFFFF) _logOutput->print('0');
+      else if (h <= 0xFFFFFF); // Do nothing
+      else if (h <= 0xFFFFFFF) _logOutput->print('0');
+      _logOutput->print(h, HEX);
+   }
 	else if (format == 'u')
 	{
 		_logOutput->print(va_arg(*args, unsigned long), DEC);

--- a/ArduinoLog.cpp
+++ b/ArduinoLog.cpp
@@ -247,9 +247,6 @@ void Logging::printFormat(const char format, va_list *args) {
 	}
 	else if (format == 'c')
 	{
-		_logOutput->print((char) va_arg(*args, int));
-	}
-	else if( format == 'C' ) {
 		char c = (char) va_arg( *args, int );
 		if (c>=0x20 && c<0x7F) {
 			_logOutput->print(c);
@@ -258,7 +255,13 @@ void Logging::printFormat(const char format, va_list *args) {
 			if (c<0xF) _logOutput->print('0');
 			_logOutput->print(c, HEX);
 		}
-    }
+	}
+	else if( format == 'C' ) {
+      // _logOutput->print("0x");
+		char c = (char) va_arg( *args, int );
+      if (c <= 0xF) _logOutput->print('0');
+		_logOutput->print(c, HEX);
+   }
 	else if(format == 't')
 	{
 		if (va_arg(*args, int) == 1)

--- a/ArduinoLog.cpp
+++ b/ArduinoLog.cpp
@@ -203,11 +203,11 @@ void Logging::printFormat(const char format, va_list *args) {
 	{		
 		_logOutput->print("0x");
 		//_logOutput->print(va_arg(*args, int), HEX);
-	    uint16_t h = (uint16_t) va_arg( *args, int );
-        if (h<0xFFF) _logOutput->print('0');
-        if (h<0xFF ) _logOutput->print('0');
-        if (h<0xF  ) _logOutput->print('0');
-        _logOutput->print(h,HEX);
+	   uint16_t h = (uint16_t) va_arg( *args, int );
+      if (h <= 0xF) _logOutput->print('0');
+      else if (h <= 0xFF); // Do nothing
+      else if (h <= 0xFFF) _logOutput->print('0');
+      _logOutput->print(h,HEX);
 	}
 	else if (format == 'p')
 	{		

--- a/ArduinoLog.h
+++ b/ArduinoLog.h
@@ -324,6 +324,8 @@ public:
 private:
 	void print(const char *format, va_list args);
 
+   void print(const char c, va_list args);
+
 	void print(const __FlashStringHelper *format, va_list args);
 
 	void print(const Printable& obj, va_list args)


### PR DESCRIPTION
When trying to use the ArduinoLog library to print a MAC address, I used the following implementation:

```C++
   // Address stored in bd_addr is in little-endian, so should be printed 
   // backwards
   for (size_t i = 0; i < sizeof(bd_addr); i++)
   {
      size_t access_idx = sizeof(bd_addr) - 1 - i;
      if (addr.addr[access_idx] < 16)
      {
         Log.info('0');
      }
      Log.info("%x", addr.addr[access_idx]);
      if (i < sizeof(bd_addr) - 1)
      {
         Log.info(':');
      }
   }
````

Where the line `Log.info('0');` yielded the following error:

```text
In file included from *ommited*.cpp:12:
*ommited*\Arduino\libraries\ArduinoLog/ArduinoLog.h: In instantiation of 'void Logging::printLevel(int, bool, T, ...) [with T = char]':
*ommited*\Arduino\libraries\ArduinoLog/ArduinoLog.h:270:14:   required from 'void Logging::info(T, Args ...) [with T = char; Args = {}]'
*ommited*.cpp:748:18:   required from here
*ommited*\Arduino\libraries\ArduinoLog/ArduinoLog.h:366:22: error: no matching function for call to 'print(char&, va_list&)'
  366 |                 print(msg, args);
      |                 ~~~~~^~~~~~~~~~~
*ommited*s\Arduino\libraries\ArduinoLog/ArduinoLog.h:329:14: note: candidate: 'void Logging::print(const arduino::__FlashStringHelper*, va_list)' (near match)
  329 |         void print(const __FlashStringHelper *format, va_list args);
      |              ^~~~~
*ommited*\Arduino\libraries\ArduinoLog/ArduinoLog.h:329:14: note:   conversion of argument 1 would be ill-formed: 
*ommited*\Arduino\libraries\ArduinoLog/ArduinoLog.h:366:23: error: invalid conversion from 'char' to 'const arduino::__FlashStringHelper*' [-fpermissive]
  366 |                 print(msg, args);
      |                       ^~~
      |                       |
      |                       char
*ommited*\Arduino\libraries\ArduinoLog/ArduinoLog.h:325:14: note: candidate: 'void Logging::print(const char*, va_list)' (near match)
  325 |         void print(const char *format, va_list args);
      |              ^~~~~
*ommited*\Arduino\libraries\ArduinoLog/ArduinoLog.h:325:14: note:   conversion of argument 1 would be ill-formed: 
*ommited*\Arduino\libraries\ArduinoLog/ArduinoLog.h:366:23: error: invalid conversion from 'char' to 'const char*' [-fpermissive]
  366 |                 print(msg, args);
      |                       ^~~
      |                       |
      |                       char
```

It seems the library was missing the overloaded version of `print` to accept a single character. This is what I implemented.