### PR TITLE
feat: improve hex printing consistency and add leading zeros only to complete full bytes

### DIFF
--- a/ArduinoLog.cpp
+++ b/ArduinoLog.cpp
@@ -196,11 +196,11 @@ void Logging::printFormat(const char format, va_list *args) {
 	{		
 		_logOutput->print("0x");
 		//_logOutput->print(va_arg(*args, int), HEX);
-	    uint16_t h = (uint16_t) va_arg( *args, int );
-        if (h<0xFFF) _logOutput->print('0');
-        if (h<0xFF ) _logOutput->print('0');
-        if (h<0xF  ) _logOutput->print('0');
-        _logOutput->print(h,HEX);
+	   uint16_t h = (uint16_t) va_arg( *args, int );
+      if (h <= 0xF) _logOutput->print('0');
+      else if (h <= 0xFF); // Do nothing
+      else if (h <= 0xFFF) _logOutput->print('0');
+      _logOutput->print(h,HEX);
 	}
 	else if (format == 'p')
 	{		


### PR DESCRIPTION
For the following code:

```c++
 Log.info("TEST"NL);
 Log.info("%X"NL, 0xE);
 Log.info("%X"NL, 0xF);
 Log.info("%X"NL, 0x10);
 Log.info("%X"NL, 0xFE);
 Log.info("%X"NL, 0xFF);
 Log.info("%X"NL, 0x100);
 Log.info("%X"NL, 0xFFE);
 Log.info("%X"NL, 0xFFF);
 Log.info("%X"NL, 0x1000);
```

The following output was received, which seems inconsistent (misses one trailing zero for edge cases) and adds too many leading zeros for small numbers. 

```text
TEST
0x000E
0x00F
0x0010
0x00FE
0x0FF
0x0100
0x0FFE
0xFFF
0x1000
```

After this change, this is the result:

```text
TEST
0x0E
0x0F
0x10
0xFE
0xFF
0x0100
0x0FFE
0x0FFF
0x1000
```

Which correctly handles the edge cases and adds trailing zeros only to complete full bytes, which seems IMHO would be the desired behaviour.
